### PR TITLE
Flowable implements io.reactivex.Publisher and put all the class in non-default packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-//  compile 'org.reactivestreams:reactive-streams:1.0.0.RC3'
+    compile 'org.reactivestreams:reactive-streams:1.0.0'
     testCompile 'junit:junit-dep:4.10'
 }
 

--- a/src/main/java/GenericOnSubscribe.java
+++ b/src/main/java/GenericOnSubscribe.java
@@ -1,5 +1,0 @@
-import java.util.function.Consumer;
-
-public interface GenericOnSubscribe<T, S> extends Consumer<S> {
-
-}

--- a/src/main/java/com/example/MyFlowable.java
+++ b/src/main/java/com/example/MyFlowable.java
@@ -2,10 +2,11 @@ package com.example;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.reactivestreams.Subscriber;
+
 import io.reactivex.consumable.Consumable;
 import io.reactivex.flowable.Flowable;
 import io.reactivex.flowable.OperatorMap;
-import io.reactivex.flowable.Subscriber;
 
 public class MyFlowable<T> implements Consumable<Subscriber<? super T>> {
 

--- a/src/main/java/com/example/MyFlowable.java
+++ b/src/main/java/com/example/MyFlowable.java
@@ -1,5 +1,11 @@
+package com.example;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import io.reactivex.consumable.Consumable;
+import io.reactivex.flowable.Flowable;
+import io.reactivex.flowable.OperatorMap;
+import io.reactivex.flowable.Subscriber;
 
 public class MyFlowable<T> implements Consumable<Subscriber<? super T>> {
 

--- a/src/main/java/io/reactivex/completable/Completable.java
+++ b/src/main/java/io/reactivex/completable/Completable.java
@@ -1,5 +1,8 @@
+package io.reactivex.completable;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import io.reactivex.consumable.Consumable;
 
 public class Completable implements Consumable<CompletableObserver> {
 

--- a/src/main/java/io/reactivex/completable/CompletableObserver.java
+++ b/src/main/java/io/reactivex/completable/CompletableObserver.java
@@ -1,3 +1,6 @@
+package io.reactivex.completable;
+import io.reactivex.nonbp.Disposable;
+
 public interface CompletableObserver {
     void onComplete();
     void onError(Throwable t);

--- a/src/main/java/io/reactivex/completable/CompletableOnSubscribe.java
+++ b/src/main/java/io/reactivex/completable/CompletableOnSubscribe.java
@@ -1,3 +1,4 @@
+package io.reactivex.completable;
 import java.util.function.Consumer;
 
 public interface CompletableOnSubscribe extends Consumer<CompletableObserver> {

--- a/src/main/java/io/reactivex/consumable/Consumable.java
+++ b/src/main/java/io/reactivex/consumable/Consumable.java
@@ -1,3 +1,4 @@
+package io.reactivex.consumable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/src/main/java/io/reactivex/flowable/Flowable.java
+++ b/src/main/java/io/reactivex/flowable/Flowable.java
@@ -1,6 +1,13 @@
+package io.reactivex.flowable;
+
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import io.reactivex.consumable.Consumable;
+import io.reactivex.nonbp.Disposable;
+import io.reactivex.observable.Observer;
+import io.reactivex.single.SingleObserver;
 
 public class Flowable<T> implements Consumable<Subscriber<? super T>> {
     

--- a/src/main/java/io/reactivex/flowable/Flowable.java
+++ b/src/main/java/io/reactivex/flowable/Flowable.java
@@ -4,12 +4,16 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import io.reactivex.consumable.Consumable;
 import io.reactivex.nonbp.Disposable;
 import io.reactivex.observable.Observer;
 import io.reactivex.single.SingleObserver;
 
-public class Flowable<T> implements Consumable<Subscriber<? super T>> {
+public class Flowable<T> implements Consumable<Subscriber<? super T>>, Publisher<T> {
     
     private final FlowableOnSubscribe<T> onSubscribe;
 
@@ -190,5 +194,4 @@ public class Flowable<T> implements Consumable<Subscriber<? super T>> {
                     }});
             }}));
     }
-    
 }

--- a/src/main/java/io/reactivex/flowable/FlowableOnSubscribe.java
+++ b/src/main/java/io/reactivex/flowable/FlowableOnSubscribe.java
@@ -1,3 +1,4 @@
+package io.reactivex.flowable;
 import java.util.function.Consumer;
 
 public interface FlowableOnSubscribe<T> extends Consumer<Subscriber<? super T>>{

--- a/src/main/java/io/reactivex/flowable/FlowableOnSubscribe.java
+++ b/src/main/java/io/reactivex/flowable/FlowableOnSubscribe.java
@@ -1,6 +1,8 @@
 package io.reactivex.flowable;
 import java.util.function.Consumer;
 
+import org.reactivestreams.Subscriber;
+
 public interface FlowableOnSubscribe<T> extends Consumer<Subscriber<? super T>>{
 
 }

--- a/src/main/java/io/reactivex/flowable/OperatorMap.java
+++ b/src/main/java/io/reactivex/flowable/OperatorMap.java
@@ -1,3 +1,4 @@
+package io.reactivex.flowable;
 import java.util.function.Function;
 
 public class OperatorMap<T, R> implements Function<Subscriber<? super R>, Subscriber<? super T>> {

--- a/src/main/java/io/reactivex/flowable/OperatorMap.java
+++ b/src/main/java/io/reactivex/flowable/OperatorMap.java
@@ -1,6 +1,9 @@
 package io.reactivex.flowable;
 import java.util.function.Function;
 
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 public class OperatorMap<T, R> implements Function<Subscriber<? super R>, Subscriber<? super T>> {
 
         private final Function<? super T, ? extends R> f;

--- a/src/main/java/io/reactivex/flowable/Subscriber.java
+++ b/src/main/java/io/reactivex/flowable/Subscriber.java
@@ -1,3 +1,4 @@
+package io.reactivex.flowable;
 public interface Subscriber<T> {
     void onNext(T t);
     void onError(Throwable t);

--- a/src/main/java/io/reactivex/flowable/Subscriber.java
+++ b/src/main/java/io/reactivex/flowable/Subscriber.java
@@ -1,7 +1,0 @@
-package io.reactivex.flowable;
-public interface Subscriber<T> {
-    void onNext(T t);
-    void onError(Throwable t);
-    void onComplete();
-    void onSubscribe(Subscription subscription);
-}

--- a/src/main/java/io/reactivex/flowable/Subscription.java
+++ b/src/main/java/io/reactivex/flowable/Subscription.java
@@ -1,5 +1,0 @@
-package io.reactivex.flowable;
-public interface Subscription {
-    void cancel();
-    void request(long n);
-}

--- a/src/main/java/io/reactivex/flowable/Subscription.java
+++ b/src/main/java/io/reactivex/flowable/Subscription.java
@@ -1,3 +1,4 @@
+package io.reactivex.flowable;
 public interface Subscription {
     void cancel();
     void request(long n);

--- a/src/main/java/io/reactivex/nonbp/Disposable.java
+++ b/src/main/java/io/reactivex/nonbp/Disposable.java
@@ -1,3 +1,4 @@
+package io.reactivex.nonbp;
 public interface Disposable {
     void dispose();
 }

--- a/src/main/java/io/reactivex/observable/Observable.java
+++ b/src/main/java/io/reactivex/observable/Observable.java
@@ -1,5 +1,13 @@
+package io.reactivex.observable;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import io.reactivex.completable.CompletableObserver;
+import io.reactivex.consumable.Consumable;
+import io.reactivex.flowable.Subscriber;
+import io.reactivex.flowable.Subscription;
+import io.reactivex.nonbp.Disposable;
+import io.reactivex.single.SingleObserver;
 
 public class Observable<T> implements Consumable<Observer<? super T>> {
 

--- a/src/main/java/io/reactivex/observable/Observable.java
+++ b/src/main/java/io/reactivex/observable/Observable.java
@@ -2,10 +2,11 @@ package io.reactivex.observable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
 import io.reactivex.completable.CompletableObserver;
 import io.reactivex.consumable.Consumable;
-import io.reactivex.flowable.Subscriber;
-import io.reactivex.flowable.Subscription;
 import io.reactivex.nonbp.Disposable;
 import io.reactivex.single.SingleObserver;
 

--- a/src/main/java/io/reactivex/observable/ObservableOnSubscribe.java
+++ b/src/main/java/io/reactivex/observable/ObservableOnSubscribe.java
@@ -1,3 +1,4 @@
+package io.reactivex.observable;
 import java.util.function.Consumer;
 
 public interface ObservableOnSubscribe<T> extends Consumer<Observer<? super T>> {

--- a/src/main/java/io/reactivex/observable/Observer.java
+++ b/src/main/java/io/reactivex/observable/Observer.java
@@ -1,3 +1,6 @@
+package io.reactivex.observable;
+import io.reactivex.nonbp.Disposable;
+
 public interface Observer<T> {
     void onNext(T t);
     void onError(Throwable t);

--- a/src/main/java/io/reactivex/single/Single.java
+++ b/src/main/java/io/reactivex/single/Single.java
@@ -1,5 +1,8 @@
+package io.reactivex.single;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import io.reactivex.consumable.Consumable;
 
 public class Single<T> implements Consumable<SingleObserver<? super T>> {
 

--- a/src/main/java/io/reactivex/single/SingleObserver.java
+++ b/src/main/java/io/reactivex/single/SingleObserver.java
@@ -1,3 +1,6 @@
+package io.reactivex.single;
+import io.reactivex.nonbp.Disposable;
+
 public interface SingleObserver<T> {
 
     void onSuccess(T t);

--- a/src/main/java/io/reactivex/single/SingleOnSubscribe.java
+++ b/src/main/java/io/reactivex/single/SingleOnSubscribe.java
@@ -1,3 +1,4 @@
+package io.reactivex.single;
 import java.util.function.Consumer;
 
 public interface SingleOnSubscribe<T> extends Consumer<SingleObserver<? super T>>{

--- a/src/test/java/io/reactivex/ObservableTest.java
+++ b/src/test/java/io/reactivex/ObservableTest.java
@@ -1,13 +1,13 @@
 package io.reactivex;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import com.example.MyFlowable;
 
 import io.reactivex.flowable.Flowable;
-import io.reactivex.flowable.Subscriber;
-import io.reactivex.flowable.Subscription;
 import io.reactivex.nonbp.Disposable;
 import io.reactivex.observable.Observable;
 import io.reactivex.observable.Observer;

--- a/src/test/java/io/reactivex/ObservableTest.java
+++ b/src/test/java/io/reactivex/ObservableTest.java
@@ -1,6 +1,17 @@
+package io.reactivex;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+
+import com.example.MyFlowable;
+
+import io.reactivex.flowable.Flowable;
+import io.reactivex.flowable.Subscriber;
+import io.reactivex.flowable.Subscription;
+import io.reactivex.nonbp.Disposable;
+import io.reactivex.observable.Observable;
+import io.reactivex.observable.Observer;
+import io.reactivex.single.Single;
 
 public class ObservableTest {
     


### PR DESCRIPTION
 to clarify what is grouped together and avoid problems with importing.
